### PR TITLE
Allowing non contributors to run gatsby new successfully

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ have already went through with the
 `gatsby new` command.
 
 ```
-gatsby new [NEW_SITE_DIRECTORY_FOR_YOUR_BLOG] git@github.com:greglobinski/gatsby-starter-simple-landing.git
+gatsby new [NEW_SITE_DIRECTORY_FOR_YOUR_BLOG] https://github.com/greglobinski/gatsby-starter-simple-landing.git
 ```
 
 ## Customization


### PR DESCRIPTION
Using the `git@` url results in the following error for non-contributors:

```
> gatsby new landing-page git@github.com:greglobinski/gatsby-starter-simple-landing.git
info Creating new site from git: git@github.com:greglobinski/gatsby-starter-simple-landing.git
Cloning into 'landing-page'...
The authenticity of host 'github.com (192.30.255.113)' can't be established.
RSA key fingerprint is SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8.
Are you sure you want to continue connecting (yes/no)? yes
Warning: Permanently added 'github.com,192.30.255.113' (RSA) to the list of known hosts.
Permission denied (publickey).
fatal: Could not read from remote repository.
Please make sure you have the correct access rights
and the repository exists.
error Command failed: git clone git@github.com:greglobinski/gatsby-starter-simple-landing.git landing-page --single-branch
  Error: Command failed: git clone git@github.com:greglobinski/gatsby-starter-simple-landing.git landing-page --single-branch
```

Using the `https` url, succeeds:

```
> gatsby new landing-page https://github.com/greglobinski/gatsby-starter-simple-landing.git
info Creating new site from git: https://github.com/greglobinski/gatsby-starter-simple-landing.git
Cloning into 'landing-page'...
remote: Counting objects: 246, done.
remote: Compressing objects: 100% (167/167), done.
remote: Total 246 (delta 98), reused 207 (delta 59), pack-reused 0
Receiving objects: 100% (246/246), 3.20 MiB | 322.00 KiB/s, done.
Resolving deltas: 100% (98/98), done.
success Created starter directory layout
```